### PR TITLE
Support specifying chunks per partition

### DIFF
--- a/xarrayms/table_proxy.py
+++ b/xarrayms/table_proxy.py
@@ -2,8 +2,9 @@ from __future__ import print_function
 
 import logging
 
-import numpy as np
 import pyrap.tables as pt
+
+log = logging.getLogger(__name__)
 
 
 class TableProxy(object):

--- a/xarrayms/tests/test_correct_read.py
+++ b/xarrayms/tests/test_correct_read.py
@@ -31,6 +31,7 @@ def create_parser():
 
     return p
 
+
 args = create_parser().parse_args()
 
 with pt.table(args.ms) as table:
@@ -56,8 +57,6 @@ with pt.table(args.ms) as table:
                          list(missing))
 
             cmp_cols = cmp_cols - missing
-
-
 
         # Select data from the relevant data from the MS
         query = ("SELECT * FROM $table "

--- a/xarrayms/xarray_ms.py
+++ b/xarrayms/xarray_ms.py
@@ -10,7 +10,6 @@ from functools import partial
 import logging
 import os
 import os.path
-import time
 
 import dask
 import dask.array as da
@@ -130,7 +129,6 @@ def xds_to_table(xds, table_name, columns=None):
         dsk.update(dask_array.__dask_graph__())
 
         array_chunks = data_array.chunks
-        array_shape = data_array.shape
 
         if not data_array.dims[row_idx] == 'row':
             raise ValueError("xds.%s.dims[0] != 'row'" % c)

--- a/xarrayms/xarray_ms.py
+++ b/xarrayms/xarray_ms.py
@@ -30,8 +30,9 @@ from xarrayms.known_table_schemas import registered_schemas
 
 _DEFAULT_PARTITION_COLUMNS = ("FIELD_ID", "DATA_DESC_ID")
 _DEFAULT_INDEX_COLUMNS = ("FIELD_ID", "DATA_DESC_ID", "TIME",)
-
 _DEFAULT_ROWCHUNKS = 100000
+
+log = logging.getLogger(__name__)
 
 
 def short_table_name(table_name):
@@ -336,7 +337,7 @@ def xds_from_table_impl(table_name, table, table_schema,
             # Read the starting row
             row = table.getcol(c, startrow=rows[0], nrow=1)
         except Exception:
-            logging.warn("Ignoring '%s' column", c, exc_info=True)
+            log.warn("Ignoring '%s' column", c)
             missing.append(c)
         else:
             # Usually we get numpy arrays


### PR DESCRIPTION
The initial row chunking strategy is often not exactly  what we want. This PR allows users to specify a chunk for each partition. This allows a bootstrapping strategy when choosing chunk sizes. For example, if we want to chunk rows on each unique time, we can do the following:

```python
xms = xds_from_ms(args.ms,
                  columns=("TIME",),
                  part_cols=("FIELD_ID", "DATA_DESC_ID"),
                  index_cols=("SCAN_NUMBER", "TIME",),
                  chunks={"row": 100000})


utime_chunks = [dask.compute(da.unique(ms.TIME.data, return_counts=True))[0]
                                                for i, ms in enumerate(xms)]

xms = xds_from_ms(args.ms,
                  part_cols=("FIELD_ID", "DATA_DESC_ID"),
                  index_cols=("SCAN_NUMBER", "TIME",),
                  chunks=[{"row": (tuple(c),)} for _, c in utime_chunks])
```