### PR TITLE
Sundry improvements

### DIFF
--- a/xarrayms/tests/test_correct_read.py
+++ b/xarrayms/tests/test_correct_read.py
@@ -1,6 +1,6 @@
 """
 Tests that data read from xarrayms for the default
-partioning and indexing scheme matches a taql query
+grouping and indexing scheme matches a taql query
 and getcol via pyrap.tables.
 
 Currently needs a Measurement Set to run.
@@ -17,7 +17,7 @@ import numpy as np
 import pyrap.tables as pt
 
 from xarrayms import xds_from_ms
-from xarrayms.xarray_ms import (_DEFAULT_PARTITION_COLUMNS,
+from xarrayms.xarray_ms import (_DEFAULT_GROUP_COLUMNS,
                                 _DEFAULT_INDEX_COLUMNS,
                                 select_clause,
                                 orderby_clause,
@@ -38,7 +38,7 @@ def create_parser():
     p = argparse.ArgumentParser()
     p.add_argument("ms")
     p.add_argument("-gc", "--group-columns", type=_split_column_str,
-                   default=",".join(_DEFAULT_PARTITION_COLUMNS))
+                   default=",".join(_DEFAULT_GROUP_COLUMNS))
     p.add_argument("-sc", "--select-columns", type=_split_column_str,
                    default=",".join(DEFAULT_SELECT))
     p.add_argument("-ic", "--index-columns", type=_split_column_str,
@@ -58,7 +58,7 @@ with pt.table(args.ms) as table:
     order = orderby_clause(index_cols)
 
     for ds in xds_from_ms(args.ms, columns=columns,
-                          part_cols=group_cols,
+                          group_cols=group_cols,
                           index_cols=index_cols):
 
         ds_cols = set(ds.data_vars.keys())

--- a/xarrayms/tests/test_correct_read.py
+++ b/xarrayms/tests/test_correct_read.py
@@ -76,11 +76,12 @@ with pt.table(args.ms) as table:
         where = where_clause(group_cols, [getattr(ds, c) for c in group_cols])
 
         # Select data from the relevant data from the MS
-        query = "SELECT * FROM $table %s %s" % (where, order)
+        query = "SELECT *, ROWID() as table_row FROM $table %s %s" % (where, order)
 
         # Compare
         with pt.taql(query) as Q:
-            for c in cmp_cols:
-                dask_data = getattr(ds, c).data.compute()
+            for c in list(cmp_cols) + ["table_row"]:
+                dask_array = getattr(ds, c).data
+                dask_data = dask_array if c == "table_row" else dask_array.compute()
                 np_data = Q.getcol(c)
                 assert np.all(dask_data == np_data)

--- a/xarrayms/tests/test_correct_write.py
+++ b/xarrayms/tests/test_correct_write.py
@@ -1,6 +1,6 @@
 """
 Tests that data written by xarrayms for the default
-partioning and indexing scheme matches a taql query
+grouping and indexing scheme matches a taql query
 and getcol via pyrap.tables.
 
 Currently needs a Measurement Set to run.
@@ -20,7 +20,7 @@ import xarray as xr
 
 from xarrayms import xds_from_ms, xds_to_table
 
-from xarrayms.xarray_ms import (_DEFAULT_PARTITION_COLUMNS,
+from xarrayms.xarray_ms import (_DEFAULT_GROUP_COLUMNS,
                                 _DEFAULT_INDEX_COLUMNS)
 
 logging.basicConfig(format="%(levelname)s - %(message)s", level=logging.WARN)
@@ -35,7 +35,7 @@ def create_parser():
     p = argparse.ArgumentParser()
     p.add_argument("ms")
     p.add_argument("-gc", "--group-columns", type=_split_column_str,
-                   default=",".join(_DEFAULT_PARTITION_COLUMNS))
+                   default=",".join(_DEFAULT_GROUP_COLUMNS))
     p.add_argument("-ic", "--index-columns", type=_split_column_str,
                    default=",".join(_DEFAULT_INDEX_COLUMNS))
     # STATE_ID is relatively innocuous
@@ -51,7 +51,7 @@ with pt.table(args.ms) as table:
     group_cols = args.group_columns
 
     for ds in xds_from_ms(args.ms, columns=[args.column],
-                          part_cols=group_cols,
+                          group_cols=group_cols,
                           index_cols=index_cols):
 
         row_chunks = ds.chunks["row"]


### PR DESCRIPTION
- Renamed part_cols to group_cols as this fits in better with the TAQL/pandas/xarray groupby terminology
- Make getcol and putcol dask array names more unique by including the rows read/written in the `tokenize` command. In practice this means that dask arrays accessing the same column in different groups/partitions of the Measurement Set are different from each other.
- Improve group/partition row sorting. Previously, a separate TAQL query was used to sort the rows in each group -- this was inefficient when many groups are created (e.g. group by SCAN_NUMBER) as it required a sort of the entire MS. Each group's rows are now lexically sorted by it's indexing column.
- Added groupby and orderby capabilities to the read and write tests, allowing testing of a greater range of cases.
- Rather than constructing a tuple encoding a concatentation of multiple getcols for a single chunk. embed a single function for each chunk, which returns the concatentation of multiple getcols. This should reduce the graph size.