### PR TITLE
Optimise getcol memory usage

### DIFF
--- a/xarrayms/xarray_ms.py
+++ b/xarrayms/xarray_ms.py
@@ -647,7 +647,10 @@ def xds_from_table(table_name, columns=None,
 
                     # Resort row id by indexing columns,
                     # eliminating the extra dimension introduced by getvarcol
-                    group_rows = rows[0][np.lexsort(group_indices)]
+                    if len(group_indices) > 0:
+                        group_rows = rows[0][np.lexsort(group_indices)]
+                    else:
+                        group_rows = rows[0]
 
                     # Get the singleton group values
                     group_values = tuple(gq.getvarcol(c, i, 1).pop(key)[0]

--- a/xarrayms/xarray_ms.py
+++ b/xarrayms/xarray_ms.py
@@ -239,28 +239,30 @@ def xds_to_table(xds, table_name, columns=None):
 
 def _chunk_getcols_np(table_proxy, column, shape, dtype, runs):
     # results shape = (sum(row_lengths),) + shape
-    result = np.empty((np.sum(runs[:,1]),) + shape, dtype=dtype)
+    result = np.empty((np.sum(runs[:, 1]),) + shape, dtype=dtype)
     rr = 0
 
     # Get data directly into the result array
     for rs, rl in runs:
-        table_proxy("getcolnp", column, result[rr:rr+rl], rs, rl)
+        table_proxy("getcolnp", column, result[rr:rr + rl], rs, rl)
         rr += rl
 
     return result
 
+
 def _chunk_getcols_object(table_proxy, column, shape, dtype, runs):
     # results shape = (sum(row_lengths),) + shape
-    result = np.empty((np.sum(runs[:,1]),) + shape, dtype=dtype)
+    result = np.empty((np.sum(runs[:, 1]),) + shape, dtype=dtype)
     rr = 0
 
     # Wrap objects (probably strings) in numpy arrays
     for rs, rl in runs:
         data = table_proxy("getcol", column, rs, rl)
-        result[rr:rr+rl] = np.asarray(data, dtype=dtype)
+        result[rr:rr + rl] = np.asarray(data, dtype=dtype)
         rr += rl
 
     return result
+
 
 def generate_table_getcols(table_name, table_key, dsk_base,
                            column, shape, dtype,
@@ -314,7 +316,7 @@ def generate_table_getcols(table_name, table_key, dsk_base,
     # For each iteration we generate one chunk
     # in the resultant dask array
     dsk = {(name, chunk) + key_extra: (_get_fn, table_key, column,
-                                        chunk_extra, dtype, runs)
+                                       chunk_extra, dtype, runs)
            for chunk, runs in enumerate(row_runs)}
 
     chunks = row_chunks + tuple((c,) for c in chunk_extra)


### PR DESCRIPTION
Previously, np.concatenate was used to aggregate all row runs in a chunk.
This meant that we needed twice us much memory - one set for all row runs and one for the concatenate result. Now, the result is preallocated, and `pyrap.tables.table.getcolnp` is used to dump data
directly into the result array.