### PR TITLE
Report TableProxy size as sum of init arguments

### DIFF
--- a/xarrayms/table_proxy.py
+++ b/xarrayms/table_proxy.py
@@ -72,32 +72,3 @@ class TableProxy(object):
             # Release the lock
             if should_lock:
                 self._table.unlock()
-
-
-if __name__ == "__main__":
-    import argparse
-
-    p = argparse.ArgumentParser()
-    p.add_argument("ms")
-    args = p.parse_args()
-
-    tp = TableProxy(args.ms, readonly=True)
-    tp("close")
-
-    try:
-        import cloudpickle
-        ntp = cloudpickle.loads(cloudpickle.dumps(tp))
-    except ImportError:
-        pass
-    except Exception:
-        logging.warn("cloudpickle failed", exc_info=True)
-
-    try:
-        import dill
-        ntp = dill.loads(dill.dumps(tp))
-    except ImportError:
-        pass
-    except Exception:
-        logging.warn("dill failed", exc_info=True)
-
-    print(ntp("getcol", "DATA", startrow=0, nrow=1).shape)

--- a/xarrayms/table_proxy.py
+++ b/xarrayms/table_proxy.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import logging
 
+from dask.sizeof import sizeof, getsizeof
 import pyrap.tables as pt
 
 log = logging.getLogger(__name__)
@@ -72,3 +73,16 @@ class TableProxy(object):
             # Release the lock
             if should_lock:
                 self._table.unlock()
+
+
+@sizeof.register(TableProxy)
+def sizeof_table_proxy(o):
+    """
+    Size only derived from members required to recreate.
+
+    This deceives dask into thinking that the proxy is small
+    and thus easy to copy in a distributed setting.
+    """
+    return (getsizeof(o._table_name) +
+            getsizeof(o._kwargs) +
+            getsizeof(o._write_lock))

--- a/xarrayms/tests/conftest.py
+++ b/xarrayms/tests/conftest.py
@@ -1,0 +1,51 @@
+import shutil
+import os
+
+import pyrap.tables as pt
+import pytest
+
+
+@pytest.fixture(scope="session")
+def ms(tmpdir_factory):
+    msdir = tmpdir_factory.mktemp("msdir", numbered=False)
+    fn = os.path.join(str(msdir), "test.ms")
+
+    create_table_query = """
+    CREATE TABLE %s
+    [FIELD_ID I4,
+    ANTENNA1 I4,
+    ANTENNA2 I4,
+    DATA_DESC_ID I4,
+    SCAN_NUMBER I4,
+    STATE_ID I4,
+    TIME R8]
+    LIMIT 10
+    """ % fn
+
+    # Common grouping columns
+    field = [0,   0,   0,   1,   1,   1,   1,   2,   2,   2]
+    ddid = [0,   0,   0,   0,   0,   0,   0,   1,   1,   1]
+    scan = [0,   1,   0,   1,   0,   1,   0,   1,   0,   1]
+
+    # Common indexing columns
+    time = [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]
+    ant1 = [0,   0,   1,   1,   1,   2,   1,   0,   0,   1]
+    ant2 = [1,   2,   2,   3,   2,   1,   0,   1,   1,   2]
+
+    # Column we'll write to
+    state = [0,   0,   0,   0,   0,   0,   0,   0,   0,   0]
+
+    # Create the table
+    with pt.taql(create_table_query) as ms:
+        ms.putcol("TIME", time)
+        ms.putcol("FIELD_ID", field)
+        ms.putcol("DATA_DESC_ID", ddid)
+        ms.putcol("ANTENNA1", ant1)
+        ms.putcol("ANTENNA2", ant2)
+        ms.putcol("SCAN_NUMBER", scan)
+        ms.putcol("STATE_ID", state)
+
+    yield fn
+
+    # Remove the temporary directory
+    shutil.rmtree(str(msdir))

--- a/xarrayms/tests/test_ms.py
+++ b/xarrayms/tests/test_ms.py
@@ -2,9 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import shutil
-import os
-
 import dask.array as da
 from mock import patch
 import numpy as np
@@ -12,60 +9,10 @@ import pyrap.tables as pt
 import pytest
 import xarray as xr
 
-from xarrayms.xarray_ms import (_DEFAULT_GROUP_COLUMNS,
-                                _DEFAULT_INDEX_COLUMNS,
-                                xds_from_ms,
+from xarrayms.xarray_ms import (xds_from_ms,
                                 xds_to_table,
-                                select_clause,
                                 orderby_clause,
-                                groupby_clause,
                                 where_clause)
-
-
-@pytest.fixture(scope="session")
-def ms(tmpdir_factory):
-    msdir = tmpdir_factory.mktemp("msdir", numbered=False)
-    fn = os.path.join(str(msdir), "test.ms")
-
-    create_table_query = """
-    CREATE TABLE %s
-    [FIELD_ID I4,
-    ANTENNA1 I4,
-    ANTENNA2 I4,
-    DATA_DESC_ID I4,
-    SCAN_NUMBER I4,
-    STATE_ID I4,
-    TIME R8]
-    LIMIT 10
-    """ % fn
-
-    # Common grouping columns
-    field = [0,   0,   0,   1,   1,   1,   1,   2,   2,   2]
-    ddid = [0,   0,   0,   0,   0,   0,   0,   1,   1,   1]
-    scan = [0,   1,   0,   1,   0,   1,   0,   1,   0,   1]
-
-    # Common indexing columns
-    time = [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]
-    ant1 = [0,   0,   1,   1,   1,   2,   1,   0,   0,   1]
-    ant2 = [1,   2,   2,   3,   2,   1,   0,   1,   1,   2]
-
-    # Column we'll write to
-    state = [0,   0,   0,   0,   0,   0,   0,   0,   0,   0]
-
-    # Create the table
-    with pt.taql(create_table_query) as ms:
-        ms.putcol("TIME", time)
-        ms.putcol("FIELD_ID", field)
-        ms.putcol("DATA_DESC_ID", ddid)
-        ms.putcol("ANTENNA1", ant1)
-        ms.putcol("ANTENNA2", ant2)
-        ms.putcol("SCAN_NUMBER", scan)
-        ms.putcol("STATE_ID", state)
-
-    yield fn
-
-    # Remove the temporary directory
-    shutil.rmtree(str(msdir))
 
 
 @pytest.mark.parametrize('group_cols', [

--- a/xarrayms/tests/test_table_proxy.py
+++ b/xarrayms/tests/test_table_proxy.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     import pickle
 
+from dask.sizeof import getsizeof, sizeof
 import numpy as np
 import pytest
 from xarrayms import TableProxy
@@ -33,3 +34,13 @@ def test_table_proxy_pickle(ms, table_kwargs):
 
     assert np.all(ant1 == ntp("getcol", "ANTENNA1"))
     assert np.all(ant2 == ntp("getcol", "ANTENNA2"))
+
+
+def test_table_proxy_sizeof(ms):
+    tp = TableProxy(ms, readonly=False)
+
+    size = getsizeof(tp._table_name)
+    size += getsizeof(tp._kwargs)
+    size += getsizeof(tp._write_lock)
+
+    assert sizeof(tp) == size

--- a/xarrayms/tests/test_table_proxy.py
+++ b/xarrayms/tests/test_table_proxy.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+import numpy as np
+import pytest
+from xarrayms import TableProxy
+
+
+@pytest.mark.parametrize("table_kwargs", [
+    {'readonly': True},
+    {'readonly': False}])
+def test_table_proxy_pickle(ms, table_kwargs):
+    tp = TableProxy(ms, **table_kwargs)
+    ntp = pickle.loads(pickle.dumps(tp))
+
+    # Table object differs
+    assert ntp._table != tp._table
+
+    # Table name match
+    assert ntp._table_name == tp._table_name
+    # Table creation kwargs match
+    assert ntp._kwargs == tp._kwargs
+
+    # Table reads match
+    ant1 = tp("getcol", "ANTENNA1")
+    ant2 = tp("getcol", "ANTENNA2")
+
+    assert np.all(ant1 == ntp("getcol", "ANTENNA1"))
+    assert np.all(ant2 == ntp("getcol", "ANTENNA2"))


### PR DESCRIPTION
Report size of TableProxy as only the size of the members required to recreate it (open the table). This encourages dask to think of the proxy as small and therefore easy to copy in a distributed setting.

Also start formally testing the pickling of the TableProxy.