### PR TITLE
Introduce per-process table cache

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 X.Y.Z (YYYY-MM-DD)
 ------------------
 
+* Introduce per-process table caching (:pr:`17`)
+
 0.1.2 (2018-07-20)
 ------------------
 

--- a/xarrayms/table_cache.py
+++ b/xarrayms/table_cache.py
@@ -1,0 +1,66 @@
+import atexit
+from collections import defaultdict
+from contextlib import contextmanager
+
+try:
+    from dask.utils import SerializableLock as Lock
+except ImportError:
+    from threading import Lock
+
+import pyrap.tables as pt
+
+
+class TableCache(object):
+    __lock = Lock()
+    __instance = None
+    __refcount = defaultdict(lambda: 0)
+    __maxsize = 100
+    __cache = {}
+
+    def __init__(self, __maxsize=100):
+        if self.__instance is not None:
+            raise RuntimeError("Singleton already initialised")
+
+    @classmethod
+    def instance(cls):
+        if cls.__instance is None:
+            with cls.__lock:
+                if cls.__instance is None:
+                    cls.__instance = cls()
+
+        return cls.__instance
+
+    @classmethod
+    @contextmanager
+    def open(cls, table, **kwargs):
+        key = (table, frozenset(kwargs.items()))
+        with cls.__lock:
+            try:
+                table = cls.__cache[key]
+            except KeyError:
+                table = pt.table(table, **kwargs)
+                table.unlock()
+                cls.__cache[key] = table
+
+            cls.__refcount[key] += 1
+
+            # TODO(sjperkins)
+            # Clear old tables intelligently
+            if len(cls.__cache) > cls.__maxsize:
+                raise ValueError("Cache size exceeded")
+
+        try:
+            yield table
+        finally:
+            with cls.__lock:
+                # TODO(sjperkins)
+                # Intelligently close tables whose __refcount drops to zero
+                cls.__refcount[key] -= 1
+
+    @classmethod
+    def clear(cls):
+        with cls.__lock:
+            cls.__cache.clear()
+
+
+atexit.register(lambda: TableCache.instance().clear())

--- a/xarrayms/table_proxy.py
+++ b/xarrayms/table_proxy.py
@@ -65,7 +65,7 @@ class TableProxy(object):
         try:
             # Acquire a lock and call the function
             if fn_requires_lock:
-                self._table.lock(write=fn.startswith("put"))
+                self._table.lock(write=self._write_lock)
 
             return getattr(self._table, fn)(*args, **kwargs)
 

--- a/xarrayms/table_proxy.py
+++ b/xarrayms/table_proxy.py
@@ -38,7 +38,7 @@ class TableProxy(object):
         self._write_lock = kwargs.get('readonly', True) is False
 
         # Force table locking mode
-        lockoptions = 'auto'
+        lockoptions = 'user'
 
         try:
             userlockopt = kwargs.pop('lockoptions')
@@ -60,18 +60,18 @@ class TableProxy(object):
 
     def __call__(self, fn, *args, **kwargs):
         # Don't lock for these functions
-        should_lock = fn not in ("close", "done")
+        fn_requires_lock = fn not in ("close", "done")
 
         try:
             # Acquire a lock and call the function
-            if should_lock:
+            if fn_requires_lock:
                 self._table.lock(write=self._write_lock)
 
             return getattr(self._table, fn)(*args, **kwargs)
 
         finally:
             # Release the lock
-            if should_lock:
+            if fn_requires_lock:
                 self._table.unlock()
 
 

--- a/xarrayms/table_proxy.py
+++ b/xarrayms/table_proxy.py
@@ -65,7 +65,7 @@ class TableProxy(object):
         try:
             # Acquire a lock and call the function
             if fn_requires_lock:
-                self._table.lock(write=self._write_lock)
+                self._table.lock(write=fn.startswith("put"))
 
             return getattr(self._table, fn)(*args, **kwargs)
 

--- a/xarrayms/tests/test_ms.py
+++ b/xarrayms/tests/test_ms.py
@@ -34,7 +34,7 @@ def test_ms_read(ms, group_cols, index_cols):
 
     order = orderby_clause(index_cols)
 
-    with pt.table(ms, lockoptions='auto') as T: # noqa
+    with pt.table(ms, lockoptions='auto') as T:  # noqa
         for ds in xds:
             group_col_values = [getattr(ds, c) for c in group_cols]
             where = where_clause(group_cols, group_col_values)

--- a/xarrayms/tests/test_ms.py
+++ b/xarrayms/tests/test_ms.py
@@ -34,15 +34,17 @@ def test_ms_read(ms, group_cols, index_cols):
 
     order = orderby_clause(index_cols)
 
-    for ds in xds:
-        where = where_clause(group_cols, [getattr(ds, c) for c in group_cols])
-        query = "SELECT * FROM $ms %s %s" % (where, order)
+    with pt.table(ms, lockoptions='auto') as T: # noqa
+        for ds in xds:
+            group_col_values = [getattr(ds, c) for c in group_cols]
+            where = where_clause(group_cols, group_col_values)
+            query = "SELECT * FROM $T %s %s" % (where, order)
 
-        with pt.taql(query) as Q:
-            for c in select_cols:
-                np_data = Q.getcol(c)
-                dask_data = getattr(ds, c).data.compute()
-                assert np.all(np_data == dask_data)
+            with pt.taql(query) as Q:
+                for c in select_cols:
+                    np_data = Q.getcol(c)
+                    dask_data = getattr(ds, c).data.compute()
+                    assert np.all(np_data == dask_data)
 
 
 @pytest.mark.parametrize('group_cols', [
@@ -60,7 +62,7 @@ def test_ms_write(ms, group_cols, index_cols):
     order = orderby_clause(index_cols)
 
     # Zero everything to be sure
-    with pt.table(ms, readonly=False) as table:
+    with pt.table(ms, readonly=False, lockoptions='auto') as table:
         table.putcol("STATE_ID", np.full(table.nrows(), 0, dtype=np.int32))
 
     xds = list(xds_from_ms(ms, columns=select_cols,
@@ -119,7 +121,7 @@ def test_fragmented_ms(ms, group_cols, index_cols):
     select_cols = index_cols + ["STATE_ID"]
 
     # Zero everything to be sure
-    with pt.table(ms, readonly=False) as table:
+    with pt.table(ms, readonly=False, lockoptions='auto') as table:
         table.putcol("STATE_ID", np.full(table.nrows(), 0, dtype=np.int32))
 
     # Patch the get_row_runs function to check that it is called
@@ -152,29 +154,31 @@ def test_fragmented_ms(ms, group_cols, index_cols):
     order = orderby_clause(index_cols)
     written_states = []
 
-    for i, ds in enumerate(xds):
-        where = where_clause(group_cols, [getattr(ds, c) for c in group_cols])
-        query = "SELECT * FROM $ms %s %s" % (where, order)
+    with pt.table(ms, readonly=True, lockoptions='auto') as table:
+        for i, ds in enumerate(xds):
+            group_col_values = [getattr(ds, c) for c in group_cols]
+            where = where_clause(group_cols, group_col_values)
+            query = "SELECT * FROM $table %s %s" % (where, order)
 
-        # Check that each column is correctly read
-        with pt.taql(query) as Q:
-            for c in select_cols:
-                np_data = Q.getcol(c)
-                dask_data = getattr(ds, c).data.compute()
-                assert np.all(np_data == dask_data)
+            # Check that each column is correctly read
+            with pt.taql(query) as Q:
+                for c in select_cols:
+                    np_data = Q.getcol(c)
+                    dask_data = getattr(ds, c).data.compute()
+                    assert np.all(np_data == dask_data)
 
-        # Now write some data to the STATE_ID column
-        state = da.arange(i, i + ds.dims['row'], chunks=ds.chunks['row'])
-        written_states.append(state)
-        state = xr.DataArray(state, dims=['row'])
-        nds = ds.assign(STATE_ID=state)
+            # Now write some data to the STATE_ID column
+            state = da.arange(i, i + ds.dims['row'], chunks=ds.chunks['row'])
+            written_states.append(state)
+            state = xr.DataArray(state, dims=['row'])
+            nds = ds.assign(STATE_ID=state)
 
-        with patch(patch_target, side_effect=mock_row_runs) as patch_fn:
-            xds_to_table(nds, ms, "STATE_ID",
-                         min_frag_level=min_frag_level).compute()
+            with patch(patch_target, side_effect=mock_row_runs) as patch_fn:
+                xds_to_table(nds, ms, "STATE_ID",
+                             min_frag_level=min_frag_level).compute()
 
-        assert patch_fn.called_once_with(min_frag_level=min_frag_level,
-                                         sort_dir="write")
+            assert patch_fn.called_once_with(min_frag_level=min_frag_level,
+                                             sort_dir="write")
 
     # Check that state has been correctly written
     xds = list(xds_from_ms(ms, columns=select_cols,

--- a/xarrayms/tests/test_table_cache.py
+++ b/xarrayms/tests/test_table_cache.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from xarrayms.table_cache import TableCache
+
+
+def test_table_cache(ms):
+    with TableCache.instance().open(ms) as table:
+        ant1 = table.getcol("ANTENNA1") # noqa
+        ant2 = table.getcol("ANTENNA2") # noqa

--- a/xarrayms/tests/test_table_cache.py
+++ b/xarrayms/tests/test_table_cache.py
@@ -7,5 +7,5 @@ from xarrayms.table_cache import TableCache
 
 def test_table_cache(ms):
     with TableCache.instance().open(ms) as table:
-        ant1 = table.getcol("ANTENNA1") # noqa
-        ant2 = table.getcol("ANTENNA2") # noqa
+        ant1 = table.getcol("ANTENNA1")  # noqa
+        ant2 = table.getcol("ANTENNA2")  # noqa

--- a/xarrayms/tests/test_table_proxy.py
+++ b/xarrayms/tests/test_table_proxy.py
@@ -20,9 +20,6 @@ def test_table_proxy_pickle(ms, table_kwargs):
     tp = TableProxy(ms, **table_kwargs)
     ntp = pickle.loads(pickle.dumps(tp))
 
-    # Table object differs
-    assert ntp._table != tp._table
-
     # Table name match
     assert ntp._table_name == tp._table_name
     # Table creation kwargs match
@@ -42,5 +39,6 @@ def test_table_proxy_sizeof(ms):
     size = getsizeof(tp._table_name)
     size += getsizeof(tp._kwargs)
     size += getsizeof(tp._write_lock)
+    size += getsizeof(tp._lockoptions)
 
     assert sizeof(tp) == size

--- a/xarrayms/xarray_ms.py
+++ b/xarrayms/xarray_ms.py
@@ -8,7 +8,6 @@ except ImportError:
     pass
 
 import collections
-from functools import partial
 import logging
 import os
 import os.path
@@ -19,11 +18,6 @@ import numpy as np
 import pyrap.tables as pt
 from six import string_types
 from six.moves import range
-
-try:
-    from cytoolz import merge
-except ImportError:
-    from toolz import merge
 
 import xarray as xr
 


### PR DESCRIPTION
dask won't copy TableProxy between worker nodes if the proxy is a **task** in the graph. Therefore, we embed TableProxy's as arguments in graph tasks which request the actual CASA table from a per process TableCache.