### PR TITLE
Table schema fixes

### DIFF
--- a/xarrayms/__init__.py
+++ b/xarrayms/__init__.py
@@ -6,30 +6,6 @@ __author__ = """Simon Perkins"""
 __email__ = 'sperkins@ska.ac.za'
 __version__ = '0.1.3'
 
-
-def get_logger():
-    import logging
-    import logging.handlers
-
-    # Console formatter, mention name
-    cfmt = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
-
-    # Console handler
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.INFO)
-    ch.setFormatter(cfmt)
-
-    logger = logging.getLogger(__name__)
-    logger.handlers = []
-    logger.setLevel(logging.DEBUG)
-    logger.addHandler(ch)
-    logger.propagate = False
-
-    return logger
-
-
-log = get_logger()
-
 from xarrayms.xarray_ms import (xds_from_table,             # noqa
                                 xds_to_table, xds_from_ms)  # noqa
 from xarrayms.table_proxy import TableProxy                 # noqa

--- a/xarrayms/__init__.py
+++ b/xarrayms/__init__.py
@@ -30,6 +30,6 @@ def get_logger():
 
 log = get_logger()
 
-from xarrayms.xarray_ms import (xds_from_table,
+from xarrayms.xarray_ms import (xds_from_table,             # noqa
                                 xds_to_table, xds_from_ms)  # noqa
 from xarrayms.table_proxy import TableProxy                 # noqa

--- a/xarrayms/known_table_schemas.py
+++ b/xarrayms/known_table_schemas.py
@@ -39,8 +39,8 @@ MS_SCHEMA = {
     "OBSERVATION_ID":   ColumnSchema(()),
     "STATE_ID":         ColumnSchema(()),
     "BASELINE_REF":     ColumnSchema(()),
-    "UVW":              ColumnSchema(('(u,v,w)',)),
-    "UVW2":             ColumnSchema(('(u,v,w)',)),
+    "UVW":              ColumnSchema(('uvw',)),
+    "UVW2":             ColumnSchema(('uvw',)),
     "DATA":             ColumnSchema(('chan', 'corr')),
     "FLOAT_DATA":       ColumnSchema(('chan', 'corr')),
     "VIDEO_POINT":      ColumnSchema(('corr',)),
@@ -60,14 +60,14 @@ MS_SCHEMA = {
 }
 
 ANTENNA_SCHEMA = {
-    "POSITION":         ColumnSchema(('(x,y,z)',)),
-    "OFFSET":           ColumnSchema(('(x,y,z)',)),
+    "POSITION":         ColumnSchema(('xyz',)),
+    "OFFSET":           ColumnSchema(('xyz',)),
 }
 
 FIELD_SCHEMA = {
-    "DELAY_DIR":        ColumnSchema(('dir', 'poly+1')),
-    "PHASE_DIR":        ColumnSchema(('dir', 'poly+1')),
-    "REFERENCE_DIR":    ColumnSchema(('dir', 'poly+1')),
+    "DELAY_DIR":        ColumnSchema(('field-dir', 'field-poly')),
+    "PHASE_DIR":        ColumnSchema(('field-dir', 'field-poly')),
+    "REFERENCE_DIR":    ColumnSchema(('field-dir', 'field-poly')),
 }
 
 SPECTRAL_WINDOW = {
@@ -80,7 +80,7 @@ SPECTRAL_WINDOW = {
 POLARIZATION = {
     "NUM_CORR":         ColumnSchema(()),
     "CORR_TYPE":        ColumnSchema(('corr',)),
-    "CORR_PRODUCT":     ColumnSchema(('corr', 'cp_idx')),
+    "CORR_PRODUCT":     ColumnSchema(('corr', 'corrprod_idx')),
 }
 
 

--- a/xarrayms/tests/conftest.py
+++ b/xarrayms/tests/conftest.py
@@ -1,6 +1,7 @@
 import shutil
 import os
 
+import numpy as np
 import pyrap.tables as pt
 import pytest
 
@@ -36,6 +37,10 @@ def ms(tmpdir_factory):
     # Column we'll write to
     state = [0,   0,   0,   0,   0,   0,   0,   0,   0,   0]
 
+    data_shape = (len(state), 16, 4)
+
+    data = np.random.random(data_shape) + np.random.random(data_shape)*1j
+
     # Create the table
     with pt.taql(create_table_query) as ms:
         ms.putcol("TIME", time)
@@ -45,6 +50,7 @@ def ms(tmpdir_factory):
         ms.putcol("ANTENNA2", ant2)
         ms.putcol("SCAN_NUMBER", scan)
         ms.putcol("STATE_ID", state)
+        ms.putcol("DATA", data)
 
     yield fn
 

--- a/xarrayms/tests/conftest.py
+++ b/xarrayms/tests/conftest.py
@@ -18,6 +18,7 @@ def ms(tmpdir_factory):
     DATA_DESC_ID I4,
     SCAN_NUMBER I4,
     STATE_ID I4,
+    DATA C8 [NDIM=2, SHAPE=[16, 4]],
     TIME R8]
     LIMIT 10
     """ % fn

--- a/xarrayms/tests/test_ms.py
+++ b/xarrayms/tests/test_ms.py
@@ -253,3 +253,12 @@ def test_table_schema(ms, group_cols, index_cols):
                            chunks={"row": 1e9}))
 
     assert xds[0].DATA.dims == ("row", "my-chan", "my-corr")
+
+    xds = list(xds_from_ms(ms, columns=["DATA"],
+                           group_cols=group_cols,
+                           index_cols=index_cols,
+                           table_schema=["MS",
+                                         {"DATA": ("my-chan", "my-corr")}],
+                           chunks={"row": 1e9}))
+
+    assert xds[0].DATA.dims == ("row", "my-chan", "my-corr")

--- a/xarrayms/tests/test_ms.py
+++ b/xarrayms/tests/test_ms.py
@@ -233,7 +233,7 @@ def test_table_schema(ms, group_cols, index_cols):
 
     # Test custom column schema specified by ColumnSchema objet
     table_schema = MS_SCHEMA.copy()
-    table_schema['DATA'] = ColumnSchema(("my_chan", "my_corr"))
+    table_schema['DATA'] = ColumnSchema(("my-chan", "my-corr"))
 
     xds = list(xds_from_ms(ms, columns=["DATA"],
                            group_cols=group_cols,
@@ -241,10 +241,10 @@ def test_table_schema(ms, group_cols, index_cols):
                            table_schema=table_schema,
                            chunks={"row": 1e9}))
 
-    assert xds[0].DATA.dims == ("row", "my_chan", "my_corr")
+    assert xds[0].DATA.dims == ("row", "my-chan", "my-corr")
 
     # Test custom column schema specified by tuple object
-    table_schema['DATA'] = ("my_chan", "my_corr")
+    table_schema['DATA'] = ("my-chan", "my-corr")
 
     xds = list(xds_from_ms(ms, columns=["DATA"],
                            group_cols=group_cols,
@@ -252,4 +252,4 @@ def test_table_schema(ms, group_cols, index_cols):
                            table_schema=table_schema,
                            chunks={"row": 1e9}))
 
-    assert xds[0].DATA.dims == ("row", "my_chan", "my_corr")
+    assert xds[0].DATA.dims == ("row", "my-chan", "my-corr")

--- a/xarrayms/tests/test_ms.py
+++ b/xarrayms/tests/test_ms.py
@@ -61,8 +61,6 @@ def test_ms_read(ms, group_cols, index_cols):
 def test_ms_write(ms, group_cols, index_cols):
     select_cols = ["STATE_ID"]
 
-    order = orderby_clause(index_cols)
-
     # Zero everything to be sure
     with pt.table(ms, readonly=False, lockoptions='auto') as table:
         table.putcol("STATE_ID", np.full(table.nrows(), 0, dtype=np.int32))
@@ -211,7 +209,7 @@ def test_unfragmented_ms(ms, group_cols, index_cols):
         return row_runs, row_resorts
 
     with patch(patch_target, side_effect=mock_row_runs) as patch_fn:
-        xds = list(xds_from_ms(ms, columns=index_cols,
+        xds = list(xds_from_ms(ms, columns=index_cols,  # noqa
                                group_cols=group_cols,
                                index_cols=index_cols,
                                min_frag_level=False,
@@ -232,7 +230,6 @@ def test_table_schema(ms, group_cols, index_cols):
                            chunks={"row": 1e9}))
 
     assert xds[0].DATA.dims == ("row", "chan", "corr")
-
 
     # Test custom column schema specified by ColumnSchema objet
     table_schema = MS_SCHEMA.copy()

--- a/xarrayms/tests/test_ms.py
+++ b/xarrayms/tests/test_ms.py
@@ -254,11 +254,12 @@ def test_table_schema(ms, group_cols, index_cols):
 
     assert xds[0].DATA.dims == ("row", "my-chan", "my-corr")
 
+    table_schema = {"DATA": ("my-chan", "my-corr")}
+
     xds = list(xds_from_ms(ms, columns=["DATA"],
                            group_cols=group_cols,
                            index_cols=index_cols,
-                           table_schema=["MS",
-                                         {"DATA": ("my-chan", "my-corr")}],
+                           table_schema=["MS", table_schema],
                            chunks={"row": 1e9}))
 
     assert xds[0].DATA.dims == ("row", "my-chan", "my-corr")

--- a/xarrayms/xarray_ms.py
+++ b/xarrayms/xarray_ms.py
@@ -693,7 +693,7 @@ def xds_from_table(table_name, columns=None,
 
         It is also possible to supply a list of strings or dicts defining
         a sequence of schemas which are combined. Later elements in the
-        list former elements override previous elements. In the following
+        list override previous elements. In the following
         example, the standard UVW MS component name scheme is overridden
         with "my-uvw".
 

--- a/xarrayms/xarray_ms.py
+++ b/xarrayms/xarray_ms.py
@@ -83,7 +83,6 @@ def _get_row_runs(rows, chunks, sort=False, sort_dir="read"):
     row_runs = []
     resorts = []
     start_row = 0
-    nruns = 0
 
     for chunk, chunk_size in enumerate(chunks[0]):
         end_row = start_row + chunk_size
@@ -106,7 +105,7 @@ def _get_row_runs(rows, chunks, sort=False, sort_dir="read"):
                 inv_argsort[argsort] = np.arange(argsort.size, dtype=dtype)
                 resorts.append(inv_argsort)
             else:
-                raise ValueError("Invalid operation %s" % op)
+                raise ValueError("Invalid operation %s" % sort_dir)
 
             chunk_rows = sorted_chunk_rows
 
@@ -298,7 +297,6 @@ def xds_to_table(xds, table_name, columns=None, **kwargs):
         dask_array = data_array.data
         dims = data_array.dims
         chunks = dask_array.chunks
-        shape = dask_array.shape
 
         if dims[0] != 'row':
             raise ValueError("xds.%s.dims[0] != 'row'" % c)
@@ -472,7 +470,7 @@ def lookup_table_schema(table_name, lookup_str):
     elif isinstance(lookup_str, string_types):
         return schemas.get(lookup_str, {})
 
-    raise TypeError("Invalid table_schema type '%s'" % type(table_schema))
+    raise TypeError("Invalid lookup_str type '%s'" % type(lookup_str))
 
 
 def column_metadata(table, columns, table_schema, rows):

--- a/xarrayms/xarray_ms.py
+++ b/xarrayms/xarray_ms.py
@@ -670,7 +670,7 @@ def xds_from_table(table_name, columns=None,
     group_cols : list or tuple, optional
         List of columns on which to group the CASA table.
         Defaults to :code:`()`
-    table_schema : str or dict, optional
+    table_schema : dict or str or list of dict or str, optional
         A schema dictionary defining the dimension naming scheme for
         each column in the table. For example:
 
@@ -682,14 +682,24 @@ def xds_from_table(table_name, columns=None,
         :code:`('row', 'uvw')` and :code:`('row', 'chan', 'corr')`
         respectively.
 
-        Alternatively a string can be supplied, which will be matched
+        A string can be supplied, which will be matched
         against existing default schemas. Examples here include
         ``MS``, ``ANTENNA`` and ``SPECTRAL_WINDOW``
         corresponding to ``Measurement Sets`` the ``ANTENNA`` subtable
         and the ``SPECTRAL_WINDOW`` subtable, respectively.
 
-        If ``None`` is supplied, the end of ``table_name`` will be
+        By default, the end of ``table_name`` will be
         inspected to see if it matches any default schemas.
+
+        It is also possible to supply a list of strings or dicts defining
+        a sequence of schemas which are combined. Later elements in the
+        list former elements override previous elements. In the following
+        example, the standard UVW MS component name scheme is overridden
+        with "my-uvw".
+
+        .. code-block:: python
+
+            ["MS", {"UVW": ("my-uvw",)}]
 
     chunks : list of dicts or dict, optional
         A :code:`{dim: chunk}` dictionary, specifying the chunking


### PR DESCRIPTION
- Correct use of table schema in `xds_from_ms`
- Support overriding default schemas
- Use simpler names for dimension schema names.
- flake8 fixes