### PR TITLE
Fix user lock handling

### DIFF
--- a/.travis/pep8.docker
+++ b/.travis/pep8.docker
@@ -1,6 +1,7 @@
 FROM kernsuite/base:3
 RUN docker-apt-install python3-pip
-RUN pip3 install pycodestyle
+RUN pip3 install pycodestyle flake8
 ADD . /code
 WORKDIR /code
+RUN flake8 xarrayms
 RUN pycodestyle xarrayms

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 X.Y.Z (YYYY-MM-DD)
 ------------------
 
+* Fix user locking (:pr:`27`)
 * Support TAQL WHERE clause (:pr:`25`)
 * Support kwargs for pyrap.tables.table (:pr:`24`)
 * Table schema fixes (:pr:`23`)

--- a/xarrayms/table_cache.py
+++ b/xarrayms/table_cache.py
@@ -19,17 +19,17 @@ class MismatchedLocks(Exception):
 
 
 class LockContext(object):
-    def __init__(self, rwlock, locktype):
-        self._rwlock = rwlock
+    def __init__(self, wrapper, locktype):
+        self._wrapper = wrapper
         self._locktype = locktype
 
     def __enter__(self):
-        self._rwlock.acquire(self._locktype)
-        return self._rwlock.table
+        self._wrapper.acquire(self._locktype)
+        return self._wrapper.table
 
     def __exit__(self, type, value, tb):
         if tb is None:
-            self._rwlock.release(self._locktype)
+            self._wrapper.release(self._locktype)
 
 
 class TableWrapper(object):

--- a/xarrayms/table_cache.py
+++ b/xarrayms/table_cache.py
@@ -9,9 +9,122 @@ except ImportError:
 
 import pyrap.tables as pt
 
+NOLOCK = 0
+READLOCK = 1
+WRITELOCK = 2
+
+
+class MismatchedLocks(Exception):
+    pass
+
+
+class LockContext(object):
+    def __init__(self, rwlock, locktype):
+        self._rwlock = rwlock
+        self._locktype = locktype
+
+    def __enter__(self):
+        self._rwlock.acquire(self._locktype)
+        return self._rwlock.table
+
+    def __exit__(self, type, value, tb):
+        if tb is None:
+            self._rwlock.release(self._locktype)
+
+
+class TableWrapper(object):
+    """
+    Wrapper around the casacore table locking mechanism.
+
+    The following invariants should always hold
+
+    .. code-block:: python
+
+        l = TableWrapper(table)
+        l.table.haslock(l.write) is (l.readlocks + l.writelocks > 0)
+        l.write is (l.writelocks > 0)
+
+    """  #
+    def __init__(self, table_name, table_kwargs):
+        self.table_name = table_name
+        self.table_kwargs = table_kwargs
+        self.table = pt.table(table_name, **table_kwargs)
+        self.readlocks = 0
+        self.writelocks = 0
+        self.write = False
+        self.writeable = self.table.iswritable()
+        self.refcount = 0
+
+    def locked_table(self, locktype):
+        return LockContext(self, locktype)
+
+    def acquire(self, locktype):
+        if locktype == READLOCK:
+            # No locks at all, acquire readlock
+            if self.readlocks + self.writelocks == 0:
+                self.table.lock(write=False)
+
+            self.readlocks += 1
+        elif locktype == WRITELOCK:
+            if not self.writeable:
+                raise ValueError("Table is not writeable")
+
+            # Acquire writelock if we had none previously
+            if self.writelocks == 0:
+                self.table.lock(write=True)
+                self.write = True
+
+            self.writelocks += 1
+        elif locktype == NOLOCK:
+            pass
+        else:
+            raise ValueError("Invalid lock type %d" % locktype)
+
+        self.refcount += 1
+
+    def release(self, locktype):
+        if locktype == READLOCK:
+            self.readlocks -= 1
+
+            if self.readlocks == 0:
+                if self.writelocks > 0:
+                    # Should be write-locked, check the invariant
+                    assert self.write is True
+                else:
+                    # Release all locks
+                    self.table.unlock()
+                    self.write = False
+            elif self.readlocks < 0:
+                raise MismatchedLocks("mismatched readlocks")
+
+        elif locktype == WRITELOCK:
+            self.writelocks -= 1
+
+            if self.writelocks == 0:
+                if self.readlocks > 0:
+                    # Downgrade from write to read lock if
+                    # there are any remaining readlocks
+                    self.write = False
+                    self.table.lock(write=False)
+                else:
+                    # Release all locks
+                    self.write = False
+                    self.table.unlock()
+            elif self.writelocks < 0:
+                raise MismatchedLocks("mismatched writelocks")
+
+        elif locktype == NOLOCK:
+            pass
+        else:
+            raise ValueError("Invalid lock type %d" % locktype)
+
+        # TODO(sjperkins)
+        # Intelligently close tables whose refcount drops to zero
+        self.refcount -= 1
+
 
 class TableCache(object):
-    __lock = Lock()
+    __cache_lock = Lock()
     __instance = None
     __refcount = defaultdict(lambda: 0)
     __maxsize = 100
@@ -24,7 +137,7 @@ class TableCache(object):
     @classmethod
     def instance(cls):
         if cls.__instance is None:
-            with cls.__lock:
+            with cls.__cache_lock:
                 if cls.__instance is None:
                     cls.__instance = cls()
 
@@ -32,34 +145,30 @@ class TableCache(object):
 
     @classmethod
     @contextmanager
-    def open(cls, table, **kwargs):
-        key = (table, frozenset(kwargs.items()))
-        with cls.__lock:
+    def open(cls, key, locktype, table_name, table_kwargs):
+        with cls.__cache_lock:
             try:
-                table = cls.__cache[key]
+                table_wrapper = cls.__cache[key]
             except KeyError:
-                table = pt.table(table, **kwargs)
-                table.unlock()
-                cls.__cache[key] = table
-
-            cls.__refcount[key] += 1
+                table_wrapper = TableWrapper(table_name, table_kwargs)
+                cls.__cache[key] = table_wrapper
 
             # TODO(sjperkins)
             # Clear old tables intelligently
             if len(cls.__cache) > cls.__maxsize:
                 raise ValueError("Cache size exceeded")
 
+            table_wrapper.acquire(locktype)
+
         try:
-            yield table
+            yield table_wrapper.table
         finally:
-            with cls.__lock:
-                # TODO(sjperkins)
-                # Intelligently close tables whose __refcount drops to zero
-                cls.__refcount[key] -= 1
+            with cls.__cache_lock:
+                table_wrapper.release(locktype)
 
     @classmethod
     def clear(cls):
-        with cls.__lock:
+        with cls.__cache_lock:
             cls.__cache.clear()
 
 

--- a/xarrayms/tests/test_ms.py
+++ b/xarrayms/tests/test_ms.py
@@ -353,7 +353,7 @@ def _proc_map_fn(args):
     xds = list(xds_from_ms(ms, columns=["STATE_ID"],
                            group_cols=["FIELD_ID"],
                            table_kwargs={'ack': False}))
-    xds[i].assign(STATE_ID=xds[i].STATE_ID + i)
+    xds[i] = xds[i].assign(STATE_ID=xds[i].STATE_ID + i)
     write = xds_to_table(xds[i], ms, ["STATE_ID"], table_kwargs={'ack': False})
     write.compute(scheduler='sync')
     return True

--- a/xarrayms/tests/test_table_cache.py
+++ b/xarrayms/tests/test_table_cache.py
@@ -2,10 +2,84 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from xarrayms.table_cache import TableCache
+import pyrap.tables as pt
+
+from xarrayms.table_cache import TableCache, TableWrapper, MismatchedLocks
+import pytest
 
 
 def test_table_cache(ms):
-    with TableCache.instance().open(ms) as table:
+    with TableCache.instance().open(1, 1, ms, {'ack': False}) as table:
         ant1 = table.getcol("ANTENNA1")  # noqa
         ant2 = table.getcol("ANTENNA2")  # noqa
+
+
+@pytest.mark.parametrize("lockseq", [
+    ["a1", "a0", "a2", "r0", "r1", "r2"],
+    ["a1", "a2", "a0", "r0", "r1", "r2"],
+    ["a1", "r1", "a0", "r0", "a2", "r2"],
+    ["a1", "a2", "a0", "r0", "r1", "r2"],
+    ["a1", "r1", "a0", "r0", "a2", "r2"],
+    ["a1", "a2", "a2", "r2", "r1", "r2"],
+    ["a2", "a2", "a1", "r2", "r1", "r2"],
+    pytest.param(["a1", "a2", "a2", "r1", "r2", "r1"],
+                 marks=pytest.mark.xfail(raises=MismatchedLocks)),
+    pytest.param(["a1", "a2", "a2", "r1", "r2"],
+                 marks=pytest.mark.xfail(reason="Acquired three locks "
+                                                "only released two")),
+
+])
+def test_locks(ms, lockseq):
+    table_wrapper = TableWrapper(ms, {'ack': False, 'readonly': False})
+
+    reads = 0
+    writes = 0
+
+    for action, locktype in lockseq:
+        locktype = int(locktype)
+
+        if action == "a":
+            if locktype == 1:
+                reads += 1
+            elif locktype == 2:
+                writes += 1
+
+            table_wrapper.acquire(locktype)
+        elif action == "r":
+            if locktype == 1:
+                reads -= 1
+            elif locktype == 2:
+                writes -= 1
+
+            table_wrapper.release(locktype)
+        else:
+            raise ValueError("Invalid action %s" % action)
+
+        # Check invariants
+        have_locks = reads + writes > 0
+        assert table_wrapper.readlocks == reads
+        assert table_wrapper.writelocks == writes
+        assert table_wrapper.table.haslock(table_wrapper.write) is have_locks
+        assert table_wrapper.write is (writes > 0)
+
+    # Check invariants
+    have_locks = reads + writes > 0
+    assert reads == 0
+    assert writes == 0
+    assert table_wrapper.readlocks == reads
+    assert table_wrapper.writelocks == writes
+    assert table_wrapper.table.haslock(table_wrapper.write) is have_locks
+    assert table_wrapper.write is (writes > 0)
+
+
+def test_context_lock(ms):
+    table_wrapper = TableWrapper(ms, {'ack': False})
+
+    with table_wrapper.locked_table(0) as T:
+        assert T.nrows() == 10
+
+    with table_wrapper.locked_table(1) as T:
+        assert T.nrows() == 10
+
+    with table_wrapper.locked_table(2) as T:
+        assert T.nrows() == 10

--- a/xarrayms/tests/test_table_cache.py
+++ b/xarrayms/tests/test_table_cache.py
@@ -29,7 +29,7 @@ def test_table_cache(ms):
                                                 "only released two")),
 
 ])
-def test_locks(ms, lockseq):
+def test_table_wrapper_locks(ms, lockseq):
     table_wrapper = TableWrapper(ms, {'ack': False, 'readonly': False})
 
     reads = 0
@@ -72,7 +72,7 @@ def test_locks(ms, lockseq):
     assert table_wrapper.write is (writes > 0)
 
 
-def test_context_lock(ms):
+def test_table_wrapper_context_lock(ms):
     table_wrapper = TableWrapper(ms, {'ack': False})
 
     with table_wrapper.locked_table(0) as T:

--- a/xarrayms/tests/test_table_cache.py
+++ b/xarrayms/tests/test_table_cache.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import pyrap.tables as pt
-
 from xarrayms.table_cache import TableCache, TableWrapper, MismatchedLocks
 import pytest
 

--- a/xarrayms/tests/test_table_proxy.py
+++ b/xarrayms/tests/test_table_proxy.py
@@ -23,7 +23,7 @@ def test_table_proxy_pickle(ms, table_kwargs):
     # Table name match
     assert ntp._table_name == tp._table_name
     # Table creation kwargs match
-    assert ntp._kwargs == tp._kwargs
+    assert ntp._table_kwargs == tp._table_kwargs
 
     # Table reads match
     ant1 = tp("getcol", "ANTENNA1")
@@ -37,8 +37,7 @@ def test_table_proxy_sizeof(ms):
     tp = TableProxy(ms, readonly=False)
 
     size = getsizeof(tp._table_name)
-    size += getsizeof(tp._kwargs)
+    size += getsizeof(tp._table_kwargs)
     size += getsizeof(tp._write_lock)
-    size += getsizeof(tp._lockoptions)
 
     assert sizeof(tp) == size


### PR DESCRIPTION
casacore table locks and unlocks can't be automatically paired via the
casacore API, as locks override previous locks and unlock will remove
all previous locks.

This commit counts the acquired read and write locks, preferring
to increment and decrement the counts and only locking where necessary.

1. When a read lock is acquired, or
2. when a lock is upgraded from a read to a write lock.
3. When a lock is downgraded from a write to a read lock.
4. Unlocking the table when all counts have dropped to zero.