### PR TITLE
setup.py fixes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.1.6 (YYYY-MM-DD)
+------------------
+
+* Fix python version package dependencies in universal wheels (:pr:`33`)
+
 0.1.5 (2019-05-21)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,20 @@
 import os
-import sys
 
 try:
     from setuptools import setup, find_packages
-    from setuptools.extension import Extension
-    from setuptools.dist import Distribution
 except ImportError as e:
     raise ImportError("%s\nPlease install setuptools." % e)
 
-
-PY2 = sys.version_info[0] == 2
-
 extras_require = {
-    'testing': ['pytest', 'pytest-runner', 'mock']
+    'testing': ['pytest', 'mock']
 }
-
 
 install_requires = [
     "dask[array] >= 1.1.0",
+    "futures >= 3.2.0; python_version < '3.0'",
     "six >= 1.10.0",
     "xarray >= 0.10.0",
 ]
-
-if PY2:
-    install_requires.append("futures >= 3.2.0")
 
 # ==================
 # Detect readthedocs


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
