### PR TITLE
Fix uniqueness of table write operations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 0.1.9 (2019-06-21)
 ------------------
+
 * Fix bug in generating unique tokens for table write operations (:pr:`36`)
 
 0.1.8 (2019-06-19)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.1.9 (2019-06-21)
+------------------
+* Fix bug in generating unique tokens for table write operations (:pr:`36`)
+
 0.1.8 (2019-06-19)
 ------------------
 

--- a/xarrayms/xarray_ms.py
+++ b/xarrayms/xarray_ms.py
@@ -338,7 +338,7 @@ def xds_to_table(xds, table_name, columns=None, **kwargs):
         schema = tuple(range(len(dask_array.shape)))
 
         # Tokenize putcol on the dask arrays
-        token = dask.base.tokenize(table_name, column)
+        token = dask.base.tokenize(table_name, column, dask_array)
         name = '-'.join((short_table_name(table_name), "putcol",
                          column, token))
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
