### PR TITLE
Correctly promote columns to lists

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.1.10 (YYYY-MM-DD)
 -------------------
 
+* Correctly promote singleton column arguments (:pr:`40`)
 * Make TableProxy pickleable (:pr:`39`)
 * Replace deprecated logging.warn with logging.warning (:pr:`37`)
 

--- a/xarrayms/tests/test_ms.py
+++ b/xarrayms/tests/test_ms.py
@@ -401,3 +401,12 @@ def test_multireadwrite(ms, group_cols, index_cols):
     writes = [xds_to_table(sds, ms, sds.data_vars.keys()) for sds in nds]
 
     da.compute(writes)
+
+
+def test_column_promotion(ms):
+    """ Test singleton columns promoted to lists """
+    xds = xds_from_ms(ms, group_cols="SCAN_NUMBER", columns=("DATA"))
+
+    for ds in xds:
+        assert "DATA" in ds
+        assert list(ds.attrs.keys()) == ["SCAN_NUMBER"]

--- a/xarrayms/xarray_ms.py
+++ b/xarrayms/xarray_ms.py
@@ -83,6 +83,17 @@ def short_table_name(table_name):
     return os.path.split(table_name.rstrip(os.sep))[1]
 
 
+def _promote_columns(columns, default):
+    if columns is None:
+        return default
+    elif isinstance(columns, tuple):
+        return list(columns)
+    elif isinstance(columns, list):
+        return columns
+    else:
+        return [columns]
+
+
 def _get_row_runs(rows, chunks, sort=False, sort_dir="read"):
     row_runs = []
     resorts = []
@@ -780,19 +791,9 @@ def xds_from_table(table_name, columns=None,
 
     taql_where = kwargs.pop("taql_where", "")
 
-    if index_cols is None:
-        index_cols = []
-    elif isinstance(index_cols, tuple):
-        index_cols = list(index_cols)
-    elif not isinstance(group_cols, list):
-        index_cols = [index_cols]
-
-    if group_cols is None:
-        group_cols = []
-    elif isinstance(group_cols, tuple):
-        group_cols = list(group_cols)
-    elif not isinstance(group_cols, list):
-        group_cols = [group_cols]
+    columns = _promote_columns(columns, None)
+    index_cols = _promote_columns(index_cols, [])
+    group_cols = _promote_columns(group_cols, [])
 
     table_proxy = TableProxy(table_name)
 
@@ -920,19 +921,9 @@ def xds_from_ms(ms, columns=None, index_cols=None, group_cols=None, **kwargs):
         xarray datasets for each group
     """
 
-    if index_cols is None:
-        index_cols = _DEFAULT_INDEX_COLUMNS
-    elif isinstance(index_cols, tuple):
-        index_cols = list(index_cols)
-    elif not isinstance(index_cols, list):
-        index_cols = [index_cols]
-
-    if group_cols is None:
-        group_cols = _DEFAULT_GROUP_COLUMNS
-    elif isinstance(group_cols, tuple):
-        group_cols = list(group_cols)
-    elif not isinstance(group_cols, list):
-        group_cols = [group_cols]
+    columns = _promote_columns(columns, None)
+    index_cols = _promote_columns(index_cols, _DEFAULT_INDEX_COLUMNS)
+    group_cols = _promote_columns(group_cols, _DEFAULT_GROUP_COLUMNS)
 
     kwargs.setdefault("table_schema", "MS")
 


### PR DESCRIPTION
- [x] Tests added / passed

  ```bash
  $ py.test -v -s xarrayms/tests
  ```

  If the pep8 tests fail, the quickest way to correct
  this is to run `autopep8` and then `flake8` and
  `pycodestyle` to fix the remaining issues.

  ```
  $ pip install -U autopep8 flake8 pycodestyle
  $ autopep8 -r -i xarrayms
  $ flake8 xarrayms
  $ pycodestyle xarrayms
  ```

- [x] Fully documented, including `HISTORY.rst` for all changes
      and one of the `docs/*-api.rst` files for new API

  To build the docs locally:

  ```
  pip install -r requirements.readthedocs.txt
  cd docs
  READTHEDOCS=True make html
  ```
